### PR TITLE
Fix skip_release_package logic

### DIFF
--- a/create_single_product
+++ b/create_single_product
@@ -1524,7 +1524,7 @@ foreach my $medium ( @$media ){
           }
 
           # add implicit the release packages to media
-          if (defined($medium->{'skip_release_package'}) && $medium->{'skip_release_package'} ne "true"){
+          if (!defined($medium->{'skip_release_package'}) || $medium->{'skip_release_package'} ne "true"){
             my $addarch = join( ",", @productarch );
             $kiwi->{instsource}->{repopackages}[0] ||= { "repopackage" => [] };
             push @{$kiwi->{instsource}->{repopackages}[0]->{repopackage}}, { "name" => $releasepkgname, addarch => $addarch };


### PR DESCRIPTION
commit 1b0f2131d4b0928c085c5b6b5ce3bca92cf97c53 broke the logic so never
added release packages unless skip_release_package was defined.