### PR TITLE
obsolete and conflict predecessor flavors

### DIFF
--- a/create_single_product
+++ b/create_single_product
@@ -1030,6 +1030,10 @@ sub createSPECfileFlavors ( $$ ) {
       }
       $product_flavors.="Provides:       product_flavor()\n";
       $product_flavors.="Provides:       flavor($flavor->{flavor})\n";
+      foreach my $predecessor ( @{$product->{'predecessor'}} ){
+	$product_flavors.="Obsoletes:      $predecessor-release-$flavor->{flavor}\n";
+	$product_flavors.="Conflicts:      $predecessor-release-$flavor->{flavor}\n";
+      }
       if (defined($flavor->{'preselected_patterns'})){
         $product_flavors.=createPreSelectPatternDeps($flavor->{'preselected_patterns'});
       }


### PR DESCRIPTION
If a product obsoletes another one, the flavor packages also need to be
migrated properly on upgrade.