### PR TITLE
Try to autodetect the obsname from OBS_SERVICE_APIURL

### DIFF
--- a/create_single_product
+++ b/create_single_product
@@ -46,8 +46,18 @@ my $bsdir;
 my $obsname;
 my $project;
 
-# hardcoded for now
-$obsname = $::ENV{'OBS_NAME'} || "build.o.o";
+my $apiurl = $::ENV{'OBS_SERVICE_APIURL'};
+if ( ! ( $obsname = $::ENV{'OBS_NAME'} ) ) {
+    if ( $apiurl =~ /^http[s]{0,1}:\/\/api.opensuse.org/ ) {
+        $obsname = "build.o.o";
+    } elsif ( $apiurl =~ /^http[s]{0,1}:\/\/api.suse.de/ ) {
+        $obsname = "build.suse.de";
+    } elsif ( $apiurl =~ /^http[s]{0,1}:\/\/api.suse.com/ ) {
+        $obsname = "build.suse.com";
+    } else {
+        die( "ERROR: Couldn't detect obsname. Specify environment variable 'OBS_NAME'" );
+    }
+}
 
 
 # read the product xml file


### PR DESCRIPTION
The environment variable OBS_SERVICE_APIURL is set by osc -
use it to auto-detect the obsname.
The auto-detection can be overridden by setting the variable
OBS_NAME.

Signed-off-by: Egbert Eich <eich@suse.com>